### PR TITLE
chore(docker): native multi-arch via shared workflow

### DIFF
--- a/.github/workflows/build-exporter.yaml
+++ b/.github/workflows/build-exporter.yaml
@@ -8,58 +8,35 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  DOCKERFILE_DIR: .
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   publish-docker-image:
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/fuellabs/prometheus-fuel-exporter
-          tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{raw}}
-            type=raw,value=sha-{{sha}}-{{date 'YYYYMMDDhhmmss'}}
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Log in to the ghcr.io registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to the docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: fuellabs
-          password: ${{ secrets.DOCKER_IO_READ_ONLY_TOKEN }}
-
-      - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE_DIR }}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/fuellabs/prometheus-fuel-exporter-build-cache:latest
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/fuellabs/prometheus-fuel-exporter-build-cache:latest,mode=max
+    uses: FuelLabs/github-actions/.github/workflows/docker-build-push.yml@master
+    secrets:
+      REGISTRY_USERNAME: ${{ github.repository_owner }}
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      auth-mode: registry-login
+      registry: ghcr.io
+      build-backend: native
+      platforms: linux/amd64,linux/arm64
+      runs-on-amd64: ubuntu-latest
+      runs-on-arm64: ubuntu-24.04-arm
+      dockerfile: Dockerfile
+      docker-context: .
+      image: ghcr.io/fuellabs/prometheus-fuel-exporter
+      flavor: latest=${{ github.ref == 'refs/heads/main' }}
+      tags: |
+        type=sha
+        type=ref,event=branch
+        type=ref,event=tag
+        type=semver,pattern={{raw}}
+        type=raw,value=sha-{{sha}}-{{date 'YYYYMMDDhhmmss'}}


### PR DESCRIPTION
## Summary
- Migrate container builds to `FuelLabs/github-actions/.github/workflows/docker-build-push.yml@master`
- Native multi-arch: `linux/amd64` + `linux/arm64` (`ubuntu-latest` / `ubuntu-24.04-arm`)

## Test plan
- [ ] CI passes on PR (amd64 + arm64 build jobs)
- [ ] Image manifest lists both architectures after merge

Part of DEVOPS-1249 / Move to graviton.

Depends on github-actions `master` with checkout/LFS inputs (DEVOPS-1248).

Made with [Cursor](https://cursor.com)